### PR TITLE
Rejuvenate log levels

### DIFF
--- a/guava-testlib/src/com/google/common/collect/testing/FeatureSpecificTestSuiteBuilder.java
+++ b/guava-testlib/src/com/google/common/collect/testing/FeatureSpecificTestSuiteBuilder.java
@@ -173,12 +173,12 @@ public abstract class FeatureSpecificTestSuiteBuilder<
   public TestSuite createTestSuite() {
     checkCanCreate();
 
-    logger.fine(" Testing: " + name);
-    logger.fine("Features: " + formatFeatureSet(features));
+    logger.finest(" Testing: " + name);
+    logger.finest("Features: " + formatFeatureSet(features));
 
     FeatureUtil.addImpliedFeatures(features);
 
-    logger.fine("Expanded: " + formatFeatureSet(features));
+    logger.finest("Expanded: " + formatFeatureSet(features));
 
     // Class parameters must be raw.
     List<Class<? extends AbstractTester>> testers = getTesters();

--- a/guava-testlib/src/com/google/common/collect/testing/PerCollectionSizeTestSuiteBuilder.java
+++ b/guava-testlib/src/com/google/common/collect/testing/PerCollectionSizeTestSuiteBuilder.java
@@ -61,7 +61,7 @@ public abstract class PerCollectionSizeTestSuiteBuilder<
     Set<Feature<?>> features = Helpers.copyToSet(getFeatures());
     List<Class<? extends AbstractTester>> testers = getTesters();
 
-    logger.fine(" Testing: " + name);
+    logger.finest(" Testing: " + name);
 
     // Split out all the specified sizes.
     Set<Feature<?>> sizesToTest = Helpers.<Feature<?>>copyToSet(CollectionSize.values());
@@ -72,7 +72,7 @@ public abstract class PerCollectionSizeTestSuiteBuilder<
     sizesToTest.retainAll(
         Arrays.asList(CollectionSize.ZERO, CollectionSize.ONE, CollectionSize.SEVERAL));
 
-    logger.fine("   Sizes: " + formatFeatureSet(sizesToTest));
+    logger.finest("   Sizes: " + formatFeatureSet(sizesToTest));
 
     if (sizesToTest.isEmpty()) {
       throw new IllegalStateException(

--- a/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java
+++ b/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java
@@ -93,7 +93,7 @@ public class TestLogHandlerTest extends TestCase {
     static final Logger logger = Logger.getLogger(ExampleClassUnderTest.class.getName());
 
     static void foo() {
-      logger.log(Level.INFO, "message", EXCEPTION);
+      logger.log(Level.FINEST, "message", EXCEPTION);
     }
   }
 }

--- a/guava-tests/test/com/google/common/io/IoTestCase.java
+++ b/guava-tests/test/com/google/common/io/IoTestCase.java
@@ -184,7 +184,7 @@ public abstract class IoTestCase extends TestCase {
     }
 
     if (!file.delete()) {
-      logger.log(Level.WARNING, "couldn't delete file: {0}", new Object[] {file});
+      logger.log(Level.FINEST, "couldn't delete file: {0}", new Object[] {file});
       return false;
     }
 

--- a/guava-tests/test/com/google/common/io/SourceSinkFactories.java
+++ b/guava-tests/test/com/google/common/io/SourceSinkFactories.java
@@ -309,7 +309,7 @@ public class SourceSinkFactories {
 
     public final void tearDown() throws IOException {
       if (!fileThreadLocal.get().delete()) {
-        logger.warning("Unable to delete file: " + fileThreadLocal.get());
+        logger.finest("Unable to delete file: " + fileThreadLocal.get());
       }
       fileThreadLocal.remove();
     }

--- a/guava-tests/test/com/google/common/util/concurrent/InterruptionUtil.java
+++ b/guava-tests/test/com/google/common/util/concurrent/InterruptionUtil.java
@@ -101,7 +101,7 @@ final class InterruptionUtil {
             Thread.interrupted();
             if (interruptingThread.isAlive()) {
               // This will be hidden by test-output redirection:
-              logger.severe("InterruptenatorTask did not exit; future tests may be affected");
+              logger.finest("InterruptenatorTask did not exit; future tests may be affected");
               /*
                * This won't do any good under JUnit 3, but I'll leave it around in
                * case we ever switch to JUnit 4:


### PR DESCRIPTION
## Introduction

We are in the process of evaluating our [research prototype Eclipse plug-in](https://github.com/ponder-lab/Logging-Level-Evolution-Plugin) that "rejuvenates" log statement levels based on how "interesting" the enclosing methods are to the developers. The assumption is that methods that are worked on more and more recently by developers should have higher log levels (e.g., INFO as compared to FINEST). Our end goal is to reduce information overload, as well as alleviate developers from manually making log level changes.

The transformation decision is made by analyzing the "degree of interest" (DOI) values of enclosing methods for logging invocations. DOI value is a kind of real number for a program element which shows how developers are interested in it. It is computed from the interaction events between developer and element, such as developer edits the element. In this project, we compute the DOI using the project's git history.

We are looking for feedback on our tool from developers. If you can, we would appreciate if you can **comment on each of the transformations** in the case that this PR is not accepted. Of course, we would also love to contribute to your project.

## Transformed Logging Statements

Here is a list of DOI values for enclosing methods of transformed log invocations in your projects:

log expression | original log level | transformed log level | type FQN | enclosing method | DOI value
-- | -- | -- | -- | -- | --
logger.fine("   Sizes: " +   formatFeatureSet(sizesToTest)) | FINE | FINEST | com.google.common.collect.testing.PerCollectionSizeTestSuiteBuilder | createTestSuite() | 0
logger.fine(" Testing: " +   name) | FINE | FINEST | com.google.common.collect.testing.FeatureSpecificTestSuiteBuilder | createTestSuite() | 0
logger.fine(" Testing: " +   name) | FINE | FINEST | com.google.common.collect.testing.PerCollectionSizeTestSuiteBuilder | createTestSuite() | 0
logger.fine("Expanded: " +   formatFeatureSet(features)) | FINE | FINEST | com.google.common.collect.testing.FeatureSpecificTestSuiteBuilder | createTestSuite() | 0
logger.finer(Platform.format("%s:   excluding because it was explicitly suppressed.",test)) | FINER | FINEST | com.google.common.collect.testing.FeatureSpecificTestSuiteBuilder | matches(junit.framework.Test) | 0
logger.fine("Features: " +   formatFeatureSet(features)) | FINE | FINEST | com.google.common.collect.testing.FeatureSpecificTestSuiteBuilder | createTestSuite() | 0
logger.log(Level.INFO,"message",EXCEPTION) | INFO | FINEST | com.google.common.testing.TestLogHandlerTest$ExampleClassUnderTest | foo() | 0
logger.log(Level.WARNING,"couldn't   delete file: {0}",new Object[]{file}) | WARNING | FINEST | com.google.common.io.IoTestCase | delete(java.io.File) | 0
logger.warning("Unable to delete   file: " + fileThreadLocal.get()) | WARNING | FINEST | com.google.common.io.SourceSinkFactories$FileFactory | tearDown() | 0
logger.severe("InterruptenatorTask   did not exit; future tests may be affected") | SEVERE | FINEST | com.google.common.util.concurrent.InterruptionUtil | tearDown() | 0





## Settings

We have several settings to analyze these DOI values. The settings we are using in this pull request are:
- Treat CONFIG log level as a category and not a traditional level, i.e., our tool ignores CONFIG log level (setting 1).
- Never lower the logging level of logging statements within catch blocks (setting 2).

We can vary these settings and rerun our if you desire.

## DOI Intervals

For your information, we also generate a list of DOI value intervals. Given this list, our tool could rejuvenate log levels by knowing which intervals the DOI values of enclosing methods for log invocations are in:

subject | DOI boundary | log level
-- | -- | --
guava-testlib | [0.0, 0.64666665) | FINEST
guava-testlib | [0.64666665, 1.2933333) | FINER
guava-testlib | [1.2933333, 1.9399999) | FINE
guava-testlib | [1.9399999, 2.5866666) | INFO
guava-testlib | [2.5866666, 3.233333) | WARNING
guava-testlib | [3.233333, 3.8799999) | SEVERE
guava-tests | [0.0, 1.0623332) | FINEST
guava-tests | [1.0623332, 2.1246665) | FINER
guava-tests | [2.1246665, 3.1869998) | FINE
guava-tests | [3.1869998, 4.249333) | INFO
guava-tests | [4.249333, 5.311666) | WARNING
guava-tests | [5.311666, 6.3739996) | SEVERE

