### PR TITLE
Rejuvenate log levels

### DIFF
--- a/guava-testlib/src/com/google/common/collect/testing/FeatureSpecificTestSuiteBuilder.java
+++ b/guava-testlib/src/com/google/common/collect/testing/FeatureSpecificTestSuiteBuilder.java
@@ -173,12 +173,12 @@ public abstract class FeatureSpecificTestSuiteBuilder<
   public TestSuite createTestSuite() {
     checkCanCreate();
 
-    logger.fine(" Testing: " + name);
-    logger.fine("Features: " + formatFeatureSet(features));
+    logger.finest(" Testing: " + name);
+    logger.finest("Features: " + formatFeatureSet(features));
 
     FeatureUtil.addImpliedFeatures(features);
 
-    logger.fine("Expanded: " + formatFeatureSet(features));
+    logger.finest("Expanded: " + formatFeatureSet(features));
 
     // Class parameters must be raw.
     List<Class<? extends AbstractTester>> testers = getTesters();

--- a/guava-testlib/src/com/google/common/collect/testing/PerCollectionSizeTestSuiteBuilder.java
+++ b/guava-testlib/src/com/google/common/collect/testing/PerCollectionSizeTestSuiteBuilder.java
@@ -61,7 +61,7 @@ public abstract class PerCollectionSizeTestSuiteBuilder<
     Set<Feature<?>> features = Helpers.copyToSet(getFeatures());
     List<Class<? extends AbstractTester>> testers = getTesters();
 
-    logger.fine(" Testing: " + name);
+    logger.finest(" Testing: " + name);
 
     // Split out all the specified sizes.
     Set<Feature<?>> sizesToTest = Helpers.<Feature<?>>copyToSet(CollectionSize.values());
@@ -72,7 +72,7 @@ public abstract class PerCollectionSizeTestSuiteBuilder<
     sizesToTest.retainAll(
         Arrays.asList(CollectionSize.ZERO, CollectionSize.ONE, CollectionSize.SEVERAL));
 
-    logger.fine("   Sizes: " + formatFeatureSet(sizesToTest));
+    logger.finest("   Sizes: " + formatFeatureSet(sizesToTest));
 
     if (sizesToTest.isEmpty()) {
       throw new IllegalStateException(

--- a/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java
+++ b/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java
@@ -93,7 +93,7 @@ public class TestLogHandlerTest extends TestCase {
     static final Logger logger = Logger.getLogger(ExampleClassUnderTest.class.getName());
 
     static void foo() {
-      logger.log(Level.INFO, "message", EXCEPTION);
+      logger.log(Level.FINEST, "message", EXCEPTION);
     }
   }
 }


### PR DESCRIPTION
## Introduction

We are in the process of evaluating our [research prototype Eclipse plug-in](https://github.com/ponder-lab/Logging-Level-Evolution-Plugin) that "rejuvenates" log statement levels based on how "interesting" the enclosing methods are to the developers. The assumption is that methods that are worked on more and more recently by developers should have higher log levels (e.g., INFO as compared to FINEST). Our end goal is to reduce information overload, as well as alleviate developers from manually making log level changes.

The transformation decision is made by analyzing the "degree of interest" (DOI) values of enclosing methods for logging invocations. DOI value is a kind of real number for a program element which shows how developers are interested in it. It is computed from the interaction events between developer and element, such as developer edits the element. In this project, we compute the DOI using the project's git history.

We are looking for feedback on our tool from developers. If you can, we would appreciate if you can **comment on each of the transformations** in the case that this PR is not accepted. Of course, we would also love to contribute to your project.

## Transformed Logging Statements

Here is a list of DOI values for enclosing methods of transformed log invocations in your projects:

log expression | original log level | transformed log level | type FQN | enclosing method | DOI value
-- | -- | -- | -- | -- | --
logger.fine("   Sizes: " +   formatFeatureSet(sizesToTest)) | FINE | FINEST | com.google.common.collect.testing.PerCollectionSizeTestSuiteBuilder | createTestSuite() | 0
logger.fine("Expanded: " +   formatFeatureSet(features)) | FINE | FINEST | com.google.common.collect.testing.FeatureSpecificTestSuiteBuilder | createTestSuite() | 0
logger.finer(Platform.format("%s:   excluding because it was explicitly suppressed.",test)) | FINER | FINEST | com.google.common.collect.testing.FeatureSpecificTestSuiteBuilder | matches(junit.framework.Test) | 0
logger.log(Level.INFO,"message",EXCEPTION) | INFO | FINEST | com.google.common.testing.TestLogHandlerTest$ExampleClassUnderTest | foo() | 0
logger.fine("Features: " +   formatFeatureSet(features)) | FINE | FINEST | com.google.common.collect.testing.FeatureSpecificTestSuiteBuilder | createTestSuite() | 0
logger.fine(" Testing: " +   name) | FINE | FINEST | com.google.common.collect.testing.PerCollectionSizeTestSuiteBuilder | createTestSuite() | 0
logger.fine(" Testing: " +   name) | FINE | FINEST | com.google.common.collect.testing.FeatureSpecificTestSuiteBuilder | createTestSuite() | 0



## Settings

We have several settings to analyze these DOI values. The settings we are using in this pull request are:
- Treat  CONFIG/WARNING/SEVERE level as a category and not a traditional level, i.e., our tool ignores CONFIG/WARNING/SEVERE log level (setting 1).
- Never lower the logging level of logging statements within catch blocks (setting 2).

We can vary these settings and rerun our if you desire.

## DOI Intervals

For your information, we also generate a list of DOI value intervals. Given this list, our tool could rejuvenate log levels by knowing which intervals the DOI values of enclosing methods for log invocations are in:

subject | DOI boundary | log level
-- | -- | --
guava-testlib | [0.0, 0.96999997) | FINEST
guava-testlib | [0.96999997, 1.9399999) | FINER
guava-testlib | [1.9399999, 2.9099998) | FINE
guava-testlib | [2.9099998, 3.8799999) | INFO
guava-tests | [0.0, 1.5934999) | FINEST
guava-tests | [1.5934999, 3.1869998) | FINER
guava-tests | [3.1869998, 4.7804995) | FINE
guava-tests | [4.7804995, 6.3739996) | INFO


