### PR TITLE
Rejuvenate log levels

### DIFF
--- a/guava-testlib/src/com/google/common/collect/testing/FeatureSpecificTestSuiteBuilder.java
+++ b/guava-testlib/src/com/google/common/collect/testing/FeatureSpecificTestSuiteBuilder.java
@@ -173,12 +173,12 @@ public abstract class FeatureSpecificTestSuiteBuilder<
   public TestSuite createTestSuite() {
     checkCanCreate();
 
-    logger.fine(" Testing: " + name);
-    logger.fine("Features: " + formatFeatureSet(features));
+    logger.finest(" Testing: " + name);
+    logger.finest("Features: " + formatFeatureSet(features));
 
     FeatureUtil.addImpliedFeatures(features);
 
-    logger.fine("Expanded: " + formatFeatureSet(features));
+    logger.finest("Expanded: " + formatFeatureSet(features));
 
     // Class parameters must be raw.
     List<Class<? extends AbstractTester>> testers = getTesters();
@@ -219,7 +219,7 @@ public abstract class FeatureSpecificTestSuiteBuilder<
       return true;
     }
     if (suppressedTests.contains(method)) {
-      logger.finer(Platform.format("%s: excluding because it was explicitly suppressed.", test));
+      logger.finest(Platform.format("%s: excluding because it was explicitly suppressed.", test));
       return false;
     }
     final TesterRequirements requirements;

--- a/guava-testlib/src/com/google/common/collect/testing/PerCollectionSizeTestSuiteBuilder.java
+++ b/guava-testlib/src/com/google/common/collect/testing/PerCollectionSizeTestSuiteBuilder.java
@@ -61,7 +61,7 @@ public abstract class PerCollectionSizeTestSuiteBuilder<
     Set<Feature<?>> features = Helpers.copyToSet(getFeatures());
     List<Class<? extends AbstractTester>> testers = getTesters();
 
-    logger.fine(" Testing: " + name);
+    logger.finest(" Testing: " + name);
 
     // Split out all the specified sizes.
     Set<Feature<?>> sizesToTest = Helpers.<Feature<?>>copyToSet(CollectionSize.values());
@@ -72,7 +72,7 @@ public abstract class PerCollectionSizeTestSuiteBuilder<
     sizesToTest.retainAll(
         Arrays.asList(CollectionSize.ZERO, CollectionSize.ONE, CollectionSize.SEVERAL));
 
-    logger.fine("   Sizes: " + formatFeatureSet(sizesToTest));
+    logger.finest("   Sizes: " + formatFeatureSet(sizesToTest));
 
     if (sizesToTest.isEmpty()) {
       throw new IllegalStateException(

--- a/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java
+++ b/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java
@@ -42,6 +42,8 @@ public class TestLogHandlerTest extends TestCase {
 
     ExampleClassUnderTest.logger.setUseParentHandlers(false); // optional
 
+    ExampleClassUnderTest.logger.setLevel(Level.ALL); // log all messages.
+
     stack.addTearDown(
         new TearDown() {
           @Override

--- a/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java
+++ b/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java
@@ -93,7 +93,7 @@ public class TestLogHandlerTest extends TestCase {
     static final Logger logger = Logger.getLogger(ExampleClassUnderTest.class.getName());
 
     static void foo() {
-      logger.log(Level.INFO, "message", EXCEPTION);
+      logger.log(Level.FINEST, "message", EXCEPTION);
     }
   }
 }

--- a/guava-tests/test/com/google/common/io/IoTestCase.java
+++ b/guava-tests/test/com/google/common/io/IoTestCase.java
@@ -184,7 +184,7 @@ public abstract class IoTestCase extends TestCase {
     }
 
     if (!file.delete()) {
-      logger.log(Level.WARNING, "couldn't delete file: {0}", new Object[] {file});
+      logger.log(Level.FINEST, "couldn't delete file: {0}", new Object[] {file});
       return false;
     }
 

--- a/guava-tests/test/com/google/common/io/SourceSinkFactories.java
+++ b/guava-tests/test/com/google/common/io/SourceSinkFactories.java
@@ -309,7 +309,7 @@ public class SourceSinkFactories {
 
     public final void tearDown() throws IOException {
       if (!fileThreadLocal.get().delete()) {
-        logger.warning("Unable to delete file: " + fileThreadLocal.get());
+        logger.finest("Unable to delete file: " + fileThreadLocal.get());
       }
       fileThreadLocal.remove();
     }

--- a/guava-tests/test/com/google/common/util/concurrent/InterruptionUtil.java
+++ b/guava-tests/test/com/google/common/util/concurrent/InterruptionUtil.java
@@ -101,7 +101,7 @@ final class InterruptionUtil {
             Thread.interrupted();
             if (interruptingThread.isAlive()) {
               // This will be hidden by test-output redirection:
-              logger.severe("InterruptenatorTask did not exit; future tests may be affected");
+              logger.finest("InterruptenatorTask did not exit; future tests may be affected");
               /*
                * This won't do any good under JUnit 3, but I'll leave it around in
                * case we ever switch to JUnit 4:

--- a/guava/src/com/google/common/base/Platform.java
+++ b/guava/src/com/google/common/base/Platform.java
@@ -80,7 +80,7 @@ final class Platform {
   }
 
   private static void logPatternCompilerError(ServiceConfigurationError e) {
-    logger.log(Level.WARNING, "Error loading regex compiler, falling back to next option", e);
+    logger.log(Level.FINEST, "Error loading regex compiler, falling back to next option", e);
   }
 
   private static final class JdkPatternCompiler implements PatternCompiler {

--- a/guava/src/com/google/common/cache/CacheBuilder.java
+++ b/guava/src/com/google/common/cache/CacheBuilder.java
@@ -978,7 +978,7 @@ public final class CacheBuilder<K, V> {
         checkState(maximumWeight != UNSET_INT, "weigher requires maximumWeight");
       } else {
         if (maximumWeight == UNSET_INT) {
-          logger.log(Level.WARNING, "ignoring weigher specified without maximumWeight");
+          logger.log(Level.FINEST, "ignoring weigher specified without maximumWeight");
         }
       }
     }

--- a/guava/src/com/google/common/io/Closer.java
+++ b/guava/src/com/google/common/io/Closer.java
@@ -248,7 +248,7 @@ public final class Closer implements Closeable {
     public void suppress(Closeable closeable, Throwable thrown, Throwable suppressed) {
       // log to the same place as Closeables
       Closeables.logger.log(
-          Level.WARNING, "Suppressing exception thrown when closing " + closeable, suppressed);
+          Level.FINEST, "Suppressing exception thrown when closing " + closeable, suppressed);
     }
   }
 

--- a/guava/src/com/google/common/reflect/ClassPath.java
+++ b/guava/src/com/google/common/reflect/ClassPath.java
@@ -550,7 +550,7 @@ public final class ClassPath {
         throws IOException {
       File[] files = directory.listFiles();
       if (files == null) {
-        logger.warning("Cannot read directory " + directory);
+        logger.finest("Cannot read directory " + directory);
         // IO error, just skip the directory
         return;
       }

--- a/guava/src/com/google/common/util/concurrent/AggregateFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AggregateFuture.java
@@ -192,7 +192,7 @@ abstract class AggregateFuture<InputT, OutputT> extends AbstractFuture.TrustedFu
             (throwable instanceof Error)
                 ? "Input Future failed with Error"
                 : "Got more than one input Future failure. Logging failures after the first";
-        logger.log(Level.SEVERE, message, throwable);
+        logger.log(Level.FINEST, message, throwable);
       }
     }
 

--- a/guava/src/com/google/common/util/concurrent/CycleDetectingLockFactory.java
+++ b/guava/src/com/google/common/util/concurrent/CycleDetectingLockFactory.java
@@ -213,7 +213,7 @@ public class CycleDetectingLockFactory {
     WARN {
       @Override
       public void handlePotentialDeadlock(PotentialDeadlockException e) {
-        logger.log(Level.SEVERE, "Detected potential deadlock", e);
+        logger.log(Level.FINEST, "Detected potential deadlock", e);
       }
     },
 

--- a/guava/src/com/google/common/util/concurrent/ServiceManager.java
+++ b/guava/src/com/google/common/util/concurrent/ServiceManager.java
@@ -207,7 +207,7 @@ public final class ServiceManager {
       // Having no services causes the manager to behave strangely. Notably, listeners are never
       // fired. To avoid this we substitute a placeholder service.
       logger.log(
-          Level.WARNING,
+          Level.FINEST,
           "ServiceManager configured with no services.  Is your application configured properly?",
           new EmptyServiceManagerWarning());
       copy = ImmutableList.<Service>of(new NoOpService());
@@ -679,7 +679,7 @@ public final class ServiceManager {
           // N.B. if we miss the STARTING event then we may never record a startup time.
           stopwatch.stop();
           if (!(service instanceof NoOpService)) {
-            logger.log(Level.FINE, "Started {0} in {1}.", new Object[] {service, stopwatch});
+            logger.log(Level.FINEST, "Started {0} in {1}.", new Object[] {service, stopwatch});
           }
         }
         // Queue our listeners
@@ -771,7 +771,7 @@ public final class ServiceManager {
       if (state != null) {
         state.transitionService(service, NEW, STARTING);
         if (!(service instanceof NoOpService)) {
-          logger.log(Level.FINE, "Starting {0}.", service);
+          logger.log(Level.FINEST, "Starting {0}.", service);
         }
       }
     }
@@ -798,7 +798,7 @@ public final class ServiceManager {
       if (state != null) {
         if (!(service instanceof NoOpService)) {
           logger.log(
-              Level.FINE,
+              Level.FINEST,
               "Service {0} has terminated. Previous state was: {1}",
               new Object[] {service, from});
         }
@@ -820,7 +820,7 @@ public final class ServiceManager {
         log &= from != State.STARTING;
         if (log) {
           logger.log(
-              Level.SEVERE,
+              Level.FINEST,
               "Service " + service + " has failed in the " + from + " state.",
               failure);
         }

--- a/guava/src/com/google/common/util/concurrent/UncaughtExceptionHandlers.java
+++ b/guava/src/com/google/common/util/concurrent/UncaughtExceptionHandlers.java
@@ -67,7 +67,7 @@ public final class UncaughtExceptionHandlers {
       try {
         // cannot use FormattingLogger due to a dependency loop
         logger.log(
-            SEVERE, String.format(Locale.ROOT, "Caught an exception in %s.  Shutting down.", t), e);
+            FINEST, String.format(Locale.ROOT, "Caught an exception in %s.  Shutting down.", t), e);
       } catch (Throwable errorInLogging) {
         // If logging fails, e.g. due to missing memory, at least try to log the
         // message and the cause for the failed logging.


### PR DESCRIPTION
## Introduction

We are in the process of evaluating our [research prototype Eclipse plug-in](https://github.com/ponder-lab/Logging-Level-Evolution-Plugin) that "rejuvenates" log statement levels based on how "interesting" the enclosing methods are to the developers. The assumption is that methods that are worked on more and more recently by developers should have higher log levels (e.g., INFO as compared to FINEST). Our end goal is to reduce information overload, as well as alleviate developers from manually making log level changes.

The transformation decision is made by analyzing the "degree of interest" (DOI) values of enclosing methods for logging invocations. DOI value is a kind of real number for a program element which shows how developers are interested in it. It is computed from the interaction events between developer and element, such as developer edits the element. In this project, we compute the DOI using the project's git history.

We are looking for feedback on our tool from developers. If you can, we would appreciate if you can **comment on each of the transformations** in the case that this PR is not accepted. Of course, we would also love to contribute to your project.

## Transformed Logging Statements

Here is a list of DOI values for enclosing methods of transformed log invocations in your projects:

log expression | original log level | transformed log level | type FQN | enclosing method | DOI value
-- | -- | -- | -- | -- | --
logger.log(Level.WARNING,"ignoring   weigher specified without maximumWeight") | WARNING | FINEST | com.google.common.cache.CacheBuilder | checkWeightWithWeigher() | 0
Closeables.logger.log(Level.WARNING,"Suppressing   exception thrown when closing " + closeable,suppressed) | WARNING | FINEST | com.google.common.io.Closer$LoggingSuppressor | suppress(java.io.Closeable,java.lang.Throwable,java.lang.Throwable) | 0
logger.log(Level.FINE,"Service {0}   has terminated. Previous state was: {1}",new Object[]{service,from}) | FINE | FINEST | com.google.common.util.concurrent.ServiceManager$ServiceListener | terminated(com.google.common.util.concurrent.Service.State) | 0
logger.log(Level.SEVERE,"Service   " + service + " has failed in the "+ from+ "   state.",failure) | SEVERE | FINEST | com.google.common.util.concurrent.ServiceManager$ServiceListener | failed(com.google.common.util.concurrent.Service.State,java.lang.Throwable) | 0
logger.log(Level.FINE,"Starting   {0}.",service) | FINE | FINEST | com.google.common.util.concurrent.ServiceManager$ServiceListener | starting() | 0
logger.log(Level.SEVERE,message,throwable) | SEVERE | FINEST | com.google.common.util.concurrent.AggregateFuture$RunningState | handleException(java.lang.Throwable) | 0
logger.log(Level.SEVERE,"Detected   potential deadlock",e) | SEVERE | FINEST | com.google.common.util.concurrent.CycleDetectingLockFactory | handlePotentialDeadlock(com.google.common.util.concurrent.CycleDetectingLockFactory.PotentialDeadlockException) | 0
logger.log(Level.WARNING,"ServiceManager   configured with no services.  Is your   application configured properly?",new EmptyServiceManagerWarning()) | WARNING | FINEST | com.google.common.util.concurrent.ServiceManager | ServiceManager(java.lang.Iterable) | 0
logger.log(Level.FINE,"Started {0}   in {1}.",new Object[]{service,stopwatch}) | FINE | FINEST | com.google.common.util.concurrent.ServiceManager$ServiceManagerState | transitionService(com.google.common.util.concurrent.Service,com.google.common.util.concurrent.Service.State,com.google.common.util.concurrent.Service.State) | 0
logger.warning("Cannot read   directory " + directory) | WARNING | FINEST | com.google.common.reflect.ClassPath$DefaultScanner | scanDirectory(java.io.File,java.lang.ClassLoader,java.lang.String,java.util.Set) | 0
logger.log(Level.WARNING,"Error   loading regex compiler, falling back to next option",e) | WARNING | FINEST | com.google.common.base.Platform | logPatternCompilerError(java.util.ServiceConfigurationError) | 0
logger.log(SEVERE,String.format(Locale.ROOT,"Caught   an exception in %s.  Shutting   down.",t),e) | SEVERE | FINEST | com.google.common.util.concurrent.UncaughtExceptionHandlers$Exiter | uncaughtException(java.lang.Thread,java.lang.Throwable) | 0
logger.finer(Platform.format("%s:   excluding because it was explicitly suppressed.",test)) | FINER | FINEST | com.google.common.collect.testing.FeatureSpecificTestSuiteBuilder | matches(junit.framework.Test) | 0
logger.fine(" Testing: " +   name) | FINE | FINEST | com.google.common.collect.testing.FeatureSpecificTestSuiteBuilder | createTestSuite() | 0
logger.log(Level.INFO,"message",EXCEPTION) | INFO | FINEST | com.google.common.testing.TestLogHandlerTest$ExampleClassUnderTest | foo() | 0
logger.fine("   Sizes: " +   formatFeatureSet(sizesToTest)) | FINE | FINEST | com.google.common.collect.testing.PerCollectionSizeTestSuiteBuilder | createTestSuite() | 0
logger.fine("Expanded: " +   formatFeatureSet(features)) | FINE | FINEST | com.google.common.collect.testing.FeatureSpecificTestSuiteBuilder | createTestSuite() | 0
logger.fine("Features: " +   formatFeatureSet(features)) | FINE | FINEST | com.google.common.collect.testing.FeatureSpecificTestSuiteBuilder | createTestSuite() | 0
logger.fine(" Testing: " +   name) | FINE | FINEST | com.google.common.collect.testing.PerCollectionSizeTestSuiteBuilder | createTestSuite() | 0
logger.log(Level.WARNING,"couldn't   delete file: {0}",new Object[]{file}) | WARNING | FINEST | com.google.common.io.IoTestCase | delete(java.io.File) | 0
logger.warning("Unable to delete   file: " + fileThreadLocal.get()) | WARNING | FINEST | com.google.common.io.SourceSinkFactories$FileFactory | tearDown() | 0
logger.severe("InterruptenatorTask   did not exit; future tests may be affected") | SEVERE | FINEST | com.google.common.util.concurrent.InterruptionUtil | tearDown() | 0




##  Manual change 
This pull request contains one manual change where we changed (please see below) to fix a test case. This is not part of the output of our tool.

```diff
diff --git a/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java b/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java
index 678f1ea4b..9ca57fab7 100644
--- a/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java
+++ b/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java
@@ -56,7 +56,7 @@ public class TestLogHandlerTest extends TestCase {
     assertTrue(handler.getStoredLogRecords().isEmpty());
     ExampleClassUnderTest.foo();
     LogRecord record = handler.getStoredLogRecords().get(0);
-    assertEquals(Level.INFO, record.getLevel());
+    assertEquals(Level.FINEST, record.getLevel());
     assertEquals("message", record.getMessage());
     assertSame(EXCEPTION, record.getThrown());
   }

```

## Settings

We have several settings to analyze these DOI values. The settings we are using in this pull request are:
- Treat CONFIG log level as a category and not a traditional level, i.e., our tool ignores CONFIG log level (setting 1).
- Never lower the logging level of logging statements within catch blocks (setting 2).
- The number of commits evaluated: 300 (setting 3).

Head: 74fc49faf283f106302794f7af82c7ab1fcb5412

We can vary these settings and rerun our if you desire.

## DOI Intervals

For your information, we also generate a list of DOI value intervals. Given this list, our tool could rejuvenate log levels by knowing which intervals the DOI values of enclosing methods for log invocations are in:

subject | DOI boundary | log level
-- | -- | --
guava | [0.0, 0.59316665) | FINEST
guava | [0.59316665, 1.1863333) | FINER
guava | [1.1863333, 1.7795) | FINE
guava | [1.7795, 2.3726666) | INFO
guava | [2.3726666, 2.9658332) | WARNING
guava | [2.9658332, 3.559) | SEVERE
guava-gwt | [0.0, 0.20216666) | FINEST
guava-gwt | [0.20216666, 0.40433332) | FINER
guava-gwt | [0.40433332, 0.60649997) | FINE
guava-gwt | [0.60649997, 0.80866665) | INFO
guava-gwt | [0.80866665, 1.0108333) | WARNING
guava-gwt | [1.0108333, 1.2129999) | SEVERE
guava-testlib | [0.0, 0.66650003) | FINEST
guava-testlib | [0.66650003, 1.3330001) | FINER
guava-testlib | [1.3330001, 1.9995) | FINE
guava-testlib | [1.9995, 2.6660001) | INFO
guava-testlib | [2.6660001, 3.3325002) | WARNING
guava-testlib | [3.3325002, 3.999) | SEVERE
guava-tests | [0.0, 1.0821667) | FINEST
guava-tests | [1.0821667, 2.1643333) | FINER
guava-tests | [2.1643333, 3.2465) | FINE
guava-tests | [3.2465, 4.3286667) | INFO
guava-tests | [4.3286667, 5.4108334) | WARNING
guava-tests | [5.4108334, 6.493) | SEVERE

